### PR TITLE
Add OpenZeppelin's `AccountERC7579` to /accounts

### DIFF
--- a/pages/accounts.mdx
+++ b/pages/accounts.mdx
@@ -41,3 +41,11 @@ Built by: [Etherspot](https://etherspot.io/)
 GitHub repo: [Reference implementation](https://github.com/erc7579/erc7579-implementation)
 
 Built by: [ERC-7579](https://erc7579.com/)
+
+## OpenZeppelin
+
+**A security-focused modular account implementation with extensible architecture**
+
+GitHub repo: [OpenZeppelin Community Contracts](https://github.com/OpenZeppelin/openzeppelin-contracts-community)
+
+Built by: [OpenZeppelin](https://www.openzeppelin.com/)

--- a/pages/accounts.mdx
+++ b/pages/accounts.mdx
@@ -46,6 +46,6 @@ Built by: [ERC-7579](https://erc7579.com/)
 
 **A security-focused modular account implementation with extensible architecture**
 
-GitHub repo: [OpenZeppelin Community Contracts](https://github.com/OpenZeppelin/openzeppelin-contracts-community)
+GitHub repo: [OpenZeppelin Community Contracts](https://github.com/OpenZeppelin/openzeppelin-community-contracts/tree/master/contracts/account/extensions)
 
 Built by: [OpenZeppelin](https://www.openzeppelin.com/)


### PR DESCRIPTION
### Description

The `AccountERC7579` and `AccountERC7579Hooked` implementations have been around for a while and we're currently working on modules too. Just adding references in `/accounts`