### PR TITLE
feat: add deprecation notices for ModuleSDK and ModuleKit

### DIFF
--- a/pages/tooling/index.mdx
+++ b/pages/tooling/index.mdx
@@ -4,6 +4,7 @@ In order to make the development of ERC-7579 compliant accounts and modules easi
 
 ## Application developers
 
+- [Rhinestone SDK](https://docs.rhinestone.dev): The recommended SDK for building with intent-based smart accounts, abstracting chains, bridging, and gas
 - [Permissionless.js](https://docs.pimlico.io/permissionless): Build with ERC-4337 smart accounts, bundlers, paymasters, and user operations
 - [ZeroDev SDK](https://docs.zerodev.app/): A modular SDK for developing DApps and wallets using smart accounts
 - [ModuleSDK](/tooling/module-sdk): A TypeScript library for using modules in applications

--- a/pages/tooling/module-sdk/account-guides/eip-7702.mdx
+++ b/pages/tooling/module-sdk/account-guides/eip-7702.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 import { Steps } from 'nextra/components'
 
 # How to use the Module SDK with EIP-7702 

--- a/pages/tooling/module-sdk/account-guides/kernel.mdx
+++ b/pages/tooling/module-sdk/account-guides/kernel.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 import { Steps } from 'nextra/components'
 
 # How to use the Module SDK with the Kernel

--- a/pages/tooling/module-sdk/account-guides/safe.mdx
+++ b/pages/tooling/module-sdk/account-guides/safe.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 import { Steps } from 'nextra/components'
 
 # How to use the Module SDK with the Safe

--- a/pages/tooling/module-sdk/account-sdks/permissionless.mdx
+++ b/pages/tooling/module-sdk/account-sdks/permissionless.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 import { Steps } from 'nextra/components'
 
 # How to use the Module SDK with Permissionless.js

--- a/pages/tooling/module-sdk/account-sdks/zerodev.mdx
+++ b/pages/tooling/module-sdk/account-sdks/zerodev.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 import { Steps } from 'nextra/components'
 
 # How to use the Module SDK with the ZeroDev SDK

--- a/pages/tooling/module-sdk/accounts/encode1271Hash.mdx
+++ b/pages/tooling/module-sdk/accounts/encode1271Hash.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # encode1271Hash
 
 Encodes a hash to be signed with ERC-1271 by an account. Note that while you should sign this hash, the unformatted hash is what should be sent to the contract.

--- a/pages/tooling/module-sdk/accounts/encode1271Signature.mdx
+++ b/pages/tooling/module-sdk/accounts/encode1271Signature.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # encode1271Signature
 
 Encodes a 1271 signature for the account type. This is the signature that should then be verified onchain.

--- a/pages/tooling/module-sdk/accounts/encodeModuleInstallationData.mdx
+++ b/pages/tooling/module-sdk/accounts/encodeModuleInstallationData.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # encodeModuleInstallationData
 
 Encodes the `initData` for a module installation.

--- a/pages/tooling/module-sdk/accounts/encodeModuleUninstallationData.mdx
+++ b/pages/tooling/module-sdk/accounts/encodeModuleUninstallationData.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # encodeModuleUninstallationData
 
 Encodes the `deInitData` for a module uninstallation.

--- a/pages/tooling/module-sdk/accounts/encodeValidatorNonce.mdx
+++ b/pages/tooling/module-sdk/accounts/encodeValidatorNonce.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # encodeValidatorNonce
 
 Encodes the validator address in the nonce key to use in ERC-7579 accounts.

--- a/pages/tooling/module-sdk/accounts/getAccount.mdx
+++ b/pages/tooling/module-sdk/accounts/getAccount.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAccount
 
 Creates a new account object.

--- a/pages/tooling/module-sdk/accounts/getInstalledModules.mdx
+++ b/pages/tooling/module-sdk/accounts/getInstalledModules.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getInstalledModules
 
 Get all the installed modules on an account.

--- a/pages/tooling/module-sdk/accounts/installModule.mdx
+++ b/pages/tooling/module-sdk/accounts/installModule.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # installModule
 
 Get the action to install a module on an account.

--- a/pages/tooling/module-sdk/accounts/isModuleInstalled.mdx
+++ b/pages/tooling/module-sdk/accounts/isModuleInstalled.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # isModuleInstalled
 
 Check if a module is installed in the account. Note that this currently only works for deployed accounts.

--- a/pages/tooling/module-sdk/accounts/uninstallModule.mdx
+++ b/pages/tooling/module-sdk/accounts/uninstallModule.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # uninstallModule
 
 Get the action to uninstall a module from an account.

--- a/pages/tooling/module-sdk/getting-started.mdx
+++ b/pages/tooling/module-sdk/getting-started.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Getting started
 
 The Module SDK is built on top of [viem](https://viem.sh/), a typesafe, modern Ethereum library. This SDK is meant to be used alongside existing account SDKs, such as [permissionless.js](https://www.npmjs.com/package/permissionless), [Biconomy](https://www.npmjs.com/package/@biconomy/account), [Zerodev](https://www.npmjs.com/package/@zerodevapp/sdk), and many more.

--- a/pages/tooling/module-sdk/glossary/types.mdx
+++ b/pages/tooling/module-sdk/glossary/types.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Types in ModuleSDK
 
 Glossary of types in ModuleSDK.

--- a/pages/tooling/module-sdk/index.mdx
+++ b/pages/tooling/module-sdk/index.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Module SDK
 
 **A TypeScript library for using smart account modules in applications**

--- a/pages/tooling/module-sdk/modules/auto-savings.mdx
+++ b/pages/tooling/module-sdk/modules/auto-savings.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Auto Savings
 
 Auto Savings is a more opinionated version of the Schedule Transfer module. It allows a user to automatically transfer a set percentage of any received token to a target ERC-4626 yield-bearing vault.

--- a/pages/tooling/module-sdk/modules/auto-savings/AUTO_SAVINGS_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/modules/auto-savings/AUTO_SAVINGS_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # AUTO_SAVINGS_ADDRESS
 
 Returns the address of the module.

--- a/pages/tooling/module-sdk/modules/auto-savings/getAutoSaveAction.mdx
+++ b/pages/tooling/module-sdk/modules/auto-savings/getAutoSaveAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAutoSaveAction
 
 Get the action to execute when the auto-save event is triggered. Note that this should be triggered by a relayer.

--- a/pages/tooling/module-sdk/modules/auto-savings/getAutoSavingAccountTokenConfig.mdx
+++ b/pages/tooling/module-sdk/modules/auto-savings/getAutoSavingAccountTokenConfig.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAutoSavingAccountTokenConfig
 
 Get the configuration of the auto-save module for a specific token.

--- a/pages/tooling/module-sdk/modules/auto-savings/getAutoSavingTokens.mdx
+++ b/pages/tooling/module-sdk/modules/auto-savings/getAutoSavingTokens.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAutoSavingTokens
 
 Get all tokens that are being auto-saved.

--- a/pages/tooling/module-sdk/modules/auto-savings/getAutoSavingsExecutor.mdx
+++ b/pages/tooling/module-sdk/modules/auto-savings/getAutoSavingsExecutor.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAutoSavingsExecutor
 
 Get the auto save executor object.

--- a/pages/tooling/module-sdk/modules/auto-savings/getDeleteAutoSavingConfigAction.mdx
+++ b/pages/tooling/module-sdk/modules/auto-savings/getDeleteAutoSavingConfigAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getDeleteAutoSavingConfigAction
 
 Get the action to delete the auto-save configuration for a token.

--- a/pages/tooling/module-sdk/modules/auto-savings/getSetAutoSavingConfigAction.mdx
+++ b/pages/tooling/module-sdk/modules/auto-savings/getSetAutoSavingConfigAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getSetAutoSavingConfigAction
 
 Get the action to set the auto-save configuration for a token.

--- a/pages/tooling/module-sdk/modules/cold-storage-hook.mdx
+++ b/pages/tooling/module-sdk/modules/cold-storage-hook.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Cold Storage Hook
 
 The Cold Storage Hook creates timelock and transfer restrictions on the users' account. It restricts execution on the account in two ways: 1) a timelock period and 2) transfers are limited to just one address.

--- a/pages/tooling/module-sdk/modules/cold-storage-hook/COLD_STORAGE_HOOK_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/modules/cold-storage-hook/COLD_STORAGE_HOOK_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # COLD_STORAGE_HOOK_ADDRESS
 
 Returns the address of the module.

--- a/pages/tooling/module-sdk/modules/cold-storage-hook/getColdStorageExecutionTime.mdx
+++ b/pages/tooling/module-sdk/modules/cold-storage-hook/getColdStorageExecutionTime.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getColdStorageExecutionTime
 
 Get the timestamp when you are able to execute a queued execution on the account.

--- a/pages/tooling/module-sdk/modules/cold-storage-hook/getColdStorageHook.mdx
+++ b/pages/tooling/module-sdk/modules/cold-storage-hook/getColdStorageHook.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getColdStorageHook
 
 Gets the cold storage hook module object.

--- a/pages/tooling/module-sdk/modules/cold-storage-hook/getColdStorageSetWaitPeriodAction.mdx
+++ b/pages/tooling/module-sdk/modules/cold-storage-hook/getColdStorageSetWaitPeriodAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getColdStorageSetWaitPeriodAction
 
 Get the action to change the wait period for cold storage account.

--- a/pages/tooling/module-sdk/modules/cold-storage-hook/getRequestTimelockedExecution.mdx
+++ b/pages/tooling/module-sdk/modules/cold-storage-hook/getRequestTimelockedExecution.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getRequestTimelockedExecution
 
 Get the action to request a timelocked execution. This will initiate a timelock, after which the execution can occur.

--- a/pages/tooling/module-sdk/modules/cold-storage-hook/getRequestTimelockedModuleConfigExecution.mdx
+++ b/pages/tooling/module-sdk/modules/cold-storage-hook/getRequestTimelockedModuleConfigExecution.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getRequestTimelockedModuleConfigExecution
 
 Get the action to request a timelocked action to change configurations on the account. This includes installing or uninstalling modules.

--- a/pages/tooling/module-sdk/modules/deadman-switch.mdx
+++ b/pages/tooling/module-sdk/modules/deadman-switch.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Deadman Switch
 
 Deadman Switch enables the recovery of an account after a specified inactive period. The user sets the target recovery address (this could be another smart account or a typical EOA wallet) along with the required period of inactivity.

--- a/pages/tooling/module-sdk/modules/deadman-switch/DEADMAN_SWITCH_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/modules/deadman-switch/DEADMAN_SWITCH_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # DEADMAN_SWITCH_ADDRESS
 
 Returns the address of the module.

--- a/pages/tooling/module-sdk/modules/deadman-switch/getDeadmanSwitch.mdx
+++ b/pages/tooling/module-sdk/modules/deadman-switch/getDeadmanSwitch.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getDeadmanSwitch
 
 Get the deadman switch module.

--- a/pages/tooling/module-sdk/modules/deadman-switch/getDeadmanSwitchConfig.mdx
+++ b/pages/tooling/module-sdk/modules/deadman-switch/getDeadmanSwitchConfig.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getDeadmanSwitchConfig
 
 Get the active configuration for the deadman switch module.

--- a/pages/tooling/module-sdk/modules/deadman-switch/getDeadmanSwitchValidatorMockSignature.mdx
+++ b/pages/tooling/module-sdk/modules/deadman-switch/getDeadmanSwitchValidatorMockSignature.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getDeadmanSwitchValidatorMockSignature
 
 Get the mock signature for the deadman switch validator in order to use for ERC-4337 gas calculations.

--- a/pages/tooling/module-sdk/modules/email-recovery.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Email Recovery
 
 The Email Recovery module allows smart accounts to be recovered using email verification powered by [ZK Email](https://zk.email). This provides an intuitive recovery method that allows anyone familiar with email to act as a guardian, while preserving privacy through zero-knowledge proofs.

--- a/pages/tooling/module-sdk/modules/email-recovery/CANCEL_EXPIRED_RECOVERY_COOLDOWN.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/CANCEL_EXPIRED_RECOVERY_COOLDOWN.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # CANCEL_EXPIRED_RECOVERY_COOLDOWN
 
 Returns the cooldown period after which a subsequent recovery attempt can be initiated by the same guardian. This helps prevent guardians threatening the liveness of recovery attempts by submitting malicious recovery hashes before honest guardians correctly submit theirs.

--- a/pages/tooling/module-sdk/modules/email-recovery/MAX_NUMBER_OF_GUARDIANS.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/MAX_NUMBER_OF_GUARDIANS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # MAX_NUMBER_OF_GUARDIANS
 
 Returns the maximum number of guardians that can be set.

--- a/pages/tooling/module-sdk/modules/email-recovery/MAX_VALIDATORS.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/MAX_VALIDATORS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # MAX_VALIDATORS
 
 Returns the maximum number of validators that can be set for email recovery.

--- a/pages/tooling/module-sdk/modules/email-recovery/MINIMUM_RECOVERY_WINDOW.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/MINIMUM_RECOVERY_WINDOW.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # MINIMUM_RECOVERY_WINDOW
 
 Returns the minimum recovery timelock in seconds.

--- a/pages/tooling/module-sdk/modules/email-recovery/UNIVERSAL_EMAIL_RECOVERY_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/UNIVERSAL_EMAIL_RECOVERY_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # UNIVERSAL_EMAIL_RECOVERY_ADDRESS
 
 Returns the address of the universal email recovery module.

--- a/pages/tooling/module-sdk/modules/email-recovery/acceptanceCommandTemplates.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/acceptanceCommandTemplates.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # acceptanceCommandTemplates
 
 Get the command templates used for guardian acceptance emails. These templates define the structure of valid acceptance commands.

--- a/pages/tooling/module-sdk/modules/email-recovery/canStartRecoveryRequest.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/canStartRecoveryRequest.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # canStartRecoveryRequest
 
 Check if a recovery request can be initiated for an account based on guardian acceptance and configuration.

--- a/pages/tooling/module-sdk/modules/email-recovery/computeAcceptanceTemplateId.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/computeAcceptanceTemplateId.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # computeAcceptanceTemplateId
 
 Compute the template ID for a given acceptance command template index.

--- a/pages/tooling/module-sdk/modules/email-recovery/computeEmailAuthAddress.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/computeEmailAuthAddress.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # computeEmailAuthAddress
 
 Compute the deterministic address for an email authentication contract using CREATE2.

--- a/pages/tooling/module-sdk/modules/email-recovery/computeRecoveryTemplateId.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/computeRecoveryTemplateId.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # computeRecoveryTemplateId
 
 Compute the template ID for a given recovery command template index.

--- a/pages/tooling/module-sdk/modules/email-recovery/extractRecoveredAccountFromAcceptanceCommand.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/extractRecoveredAccountFromAcceptanceCommand.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # extractRecoveredAccountFromAcceptanceCommand
 
 Extract the account address from an acceptance email command's parameters.

--- a/pages/tooling/module-sdk/modules/email-recovery/extractRecoveredAccountFromRecoveryCommand.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/extractRecoveredAccountFromRecoveryCommand.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # extractRecoveredAccountFromRecoveryCommand
 
 Extract the account address from a recovery email command's parameters.

--- a/pages/tooling/module-sdk/modules/email-recovery/getAddGuardianAction.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getAddGuardianAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAddGuardianAction
 
 Generate the transaction data needed to add a new guardian to an account.

--- a/pages/tooling/module-sdk/modules/email-recovery/getAllGuardians.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getAllGuardians.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAllGuardians
 
 Get an array of all guardian addresses associated with an account.

--- a/pages/tooling/module-sdk/modules/email-recovery/getAllowValidatorRecoveryAction.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getAllowValidatorRecoveryAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAllowValidatorRecoveryAction
 
 Generate the transaction data needed to allow a validator to perform recovery actions. This configures which validator and function selector can be used for account recovery.

--- a/pages/tooling/module-sdk/modules/email-recovery/getAllowedSelectors.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getAllowedSelectors.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAllowedSelectors
 
 Get the list of function selectors that are allowed for recovery operations on an account.

--- a/pages/tooling/module-sdk/modules/email-recovery/getAllowedValidators.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getAllowedValidators.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAllowedValidators
 
 Get the list of validators that are allowed to perform recovery operations for an account.

--- a/pages/tooling/module-sdk/modules/email-recovery/getCancelExpiredRecoveryAction.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getCancelExpiredRecoveryAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getCancelExpiredRecoveryAction
 
 Generate the transaction data needed to cancel an expired recovery request for an account.

--- a/pages/tooling/module-sdk/modules/email-recovery/getCancelRecoveryAction.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getCancelRecoveryAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getCancelRecoveryAction
 
 Generate the transaction data needed to cancel an ongoing recovery request.

--- a/pages/tooling/module-sdk/modules/email-recovery/getChangeThresholdAction.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getChangeThresholdAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getChangeThresholdAction
 
 Generate the transaction data needed to change the guardian approval threshold for an account.

--- a/pages/tooling/module-sdk/modules/email-recovery/getCompleteRecoveryAction.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getCompleteRecoveryAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getCompleteRecoveryAction
 
 Generate the transaction data needed to complete an account recovery process.

--- a/pages/tooling/module-sdk/modules/email-recovery/getDisallowValidatorRecoveryAction.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getDisallowValidatorRecoveryAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getDisallowValidatorRecoveryAction
 
 Generate the transaction data needed to remove a validator's recovery permissions.

--- a/pages/tooling/module-sdk/modules/email-recovery/getDkim.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getDkim.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getDkim
 
 Get the address of the DKIM verification contract used for validating email signatures.

--- a/pages/tooling/module-sdk/modules/email-recovery/getEmailAuthImplementation.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getEmailAuthImplementation.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getEmailAuthImplementation
 
 Get the address of the email authentication implementation contract used for recovery operations.

--- a/pages/tooling/module-sdk/modules/email-recovery/getGuardian.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getGuardian.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getGuardian
 
 Get the status and weight of a specific guardian for an account.

--- a/pages/tooling/module-sdk/modules/email-recovery/getGuardianConfig.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getGuardianConfig.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getGuardianConfig
 
 Get the current guardian configuration for an account, including counts, weights, and threshold.

--- a/pages/tooling/module-sdk/modules/email-recovery/getHandleAcceptanceAction.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getHandleAcceptanceAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getHandleAcceptanceAction
 
 Generate the transaction data needed to process a guardian's acceptance email and set up their email authentication.

--- a/pages/tooling/module-sdk/modules/email-recovery/getHandleRecoveryAction.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getHandleRecoveryAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getHandleRecoveryAction
 
 Generate the transaction data needed to process a guardian's recovery email request.

--- a/pages/tooling/module-sdk/modules/email-recovery/getPreviousRecoveryRequest.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getPreviousRecoveryRequest.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getPreviousRecoveryRequest
 
 Get details about the previous recovery request for an account, including the guardian who initiated it and the cooldown period for cancellation.

--- a/pages/tooling/module-sdk/modules/email-recovery/getRecoveryConfig.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getRecoveryConfig.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getRecoveryConfig
 
 Get the recovery configuration for an account, including the delay period and expiry time.

--- a/pages/tooling/module-sdk/modules/email-recovery/getRecoveryRequest.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getRecoveryRequest.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getRecoveryRequest
 
 Get the current recovery request details for an account, including execution timeframes, current guardian approval weight, and recovery data hash.

--- a/pages/tooling/module-sdk/modules/email-recovery/getRemoveGuardianAction.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getRemoveGuardianAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getRemoveGuardianAction
 
 Generate the transaction data needed to remove a guardian from an account.

--- a/pages/tooling/module-sdk/modules/email-recovery/getUniversalEmailRecoveryExecutor.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getUniversalEmailRecoveryExecutor.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getUniversalEmailRecoveryExecutor
 
 Get the Universal Email Recovery executor module object.

--- a/pages/tooling/module-sdk/modules/email-recovery/getUpdateRecoveryConfigAction.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getUpdateRecoveryConfigAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getUpdateRecoveryConfigAction
 
 Generate the transaction data needed to update the recovery configuration for an account.

--- a/pages/tooling/module-sdk/modules/email-recovery/getVerifier.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/getVerifier.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getVerifier
 
 Get the address of the email verifier contract used for recovery operations.

--- a/pages/tooling/module-sdk/modules/email-recovery/hasGuardianVoted.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/hasGuardianVoted.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # hasGuardianVoted
 
 Check if a specific guardian has already voted on the current recovery request for an account.

--- a/pages/tooling/module-sdk/modules/email-recovery/isActivated.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/isActivated.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # isActivated
 
 Check if email recovery is activated for an account by verifying if guardians have been configured.

--- a/pages/tooling/module-sdk/modules/email-recovery/recoveryCommandTemplates.mdx
+++ b/pages/tooling/module-sdk/modules/email-recovery/recoveryCommandTemplates.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # recoveryCommandTemplates
 
 Get the command templates used for account recovery emails. These templates define the structure of valid recovery commands.

--- a/pages/tooling/module-sdk/modules/hook-multi-plexer.mdx
+++ b/pages/tooling/module-sdk/modules/hook-multi-plexer.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Hook MultiPlexer
 
 The Hook MultiPlexer is an opinionated router for combining multiple hook modules. Hooks are modules that are triggered before or after execution and can be used to enforce certain smart account behavior. Some examples of hooks include spending limits, white/blacklists, and more. This is an important module for accounts with only one global hook slot.

--- a/pages/tooling/module-sdk/modules/hook-multi-plexer/HOOK_MULTI_PLEXER_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/modules/hook-multi-plexer/HOOK_MULTI_PLEXER_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # HOOK_MULTI_PLEXER_ADDRESS
 
 Returns the address of the module.

--- a/pages/tooling/module-sdk/modules/hook-multi-plexer/getAddHookAction.mdx
+++ b/pages/tooling/module-sdk/modules/hook-multi-plexer/getAddHookAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAddHookAction
 
 Get the action to add a hook to the multi-plexer.

--- a/pages/tooling/module-sdk/modules/hook-multi-plexer/getHookMultiPlexer.mdx
+++ b/pages/tooling/module-sdk/modules/hook-multi-plexer/getHookMultiPlexer.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getHookMultiPlexer
 
 Get the hook multiplexer.

--- a/pages/tooling/module-sdk/modules/hook-multi-plexer/getHooks.mdx
+++ b/pages/tooling/module-sdk/modules/hook-multi-plexer/getHooks.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getHooks
 
 Get all installed hooks.

--- a/pages/tooling/module-sdk/modules/hook-multi-plexer/getRemoveHookAction.mdx
+++ b/pages/tooling/module-sdk/modules/hook-multi-plexer/getRemoveHookAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getRemoveHookAction
 
 Get the action to remove a hook from the multi-plexer.

--- a/pages/tooling/module-sdk/modules/multi-factor.mdx
+++ b/pages/tooling/module-sdk/modules/multi-factor.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Multi Factor
 
 The Multi Factor is a multiplexer, which allows developers to compose any set of signer modules together. For example, passkeys can be set as the main signer, but passkeys and an ECDSA validation scheme are required when making high-value transfers.

--- a/pages/tooling/module-sdk/modules/multi-factor/MULTI_FACTOR_VALIDATOR_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/modules/multi-factor/MULTI_FACTOR_VALIDATOR_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # MULTI_FACTOR_VALIDATOR_ADDRESS
 
 Returns the address of the module.

--- a/pages/tooling/module-sdk/modules/multi-factor/getMFAValidatorMockSignature.mdx
+++ b/pages/tooling/module-sdk/modules/multi-factor/getMFAValidatorMockSignature.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getMFAValidatorMockSignature
 
 Get the mock signature for the multi-factor authentication validator in order to use for ERC-4337 gas calculations.

--- a/pages/tooling/module-sdk/modules/multi-factor/getMultiFactorValidator.mdx
+++ b/pages/tooling/module-sdk/modules/multi-factor/getMultiFactorValidator.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getMultiFactorValidator
 
 Get the multi-factor validator module object.

--- a/pages/tooling/module-sdk/modules/multi-factor/getRemoveMFAValidatorAction.mdx
+++ b/pages/tooling/module-sdk/modules/multi-factor/getRemoveMFAValidatorAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getRemoveMFAValidatorAction
 
 Gets the action to remove a multi-factor sub-validator.

--- a/pages/tooling/module-sdk/modules/multi-factor/getSetMFAThresholdAction.mdx
+++ b/pages/tooling/module-sdk/modules/multi-factor/getSetMFAThresholdAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getSetMFAThresholdAction
 
 Get the action to set the MFA threshold.

--- a/pages/tooling/module-sdk/modules/multi-factor/getSetMFAValidatorAction.mdx
+++ b/pages/tooling/module-sdk/modules/multi-factor/getSetMFAValidatorAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getSetMFAValidatorAction
 
 Get the action to add a new sub-validator to the multi-factor module.

--- a/pages/tooling/module-sdk/modules/multi-factor/isMFASubValidator.mdx
+++ b/pages/tooling/module-sdk/modules/multi-factor/isMFASubValidator.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # isMFASubValidator
 
 Check if a validator is added as a sub-validator to the multi-factor module.

--- a/pages/tooling/module-sdk/modules/omni-account/ACCOUNT_LOCKER_HOOK.mdx
+++ b/pages/tooling/module-sdk/modules/omni-account/ACCOUNT_LOCKER_HOOK.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # ACCOUNT_LOCKER_HOOK
 
 Returns the address of the module.

--- a/pages/tooling/module-sdk/modules/omni-account/ACCOUNT_LOCKER_SOURCE_EXECUTOR.mdx
+++ b/pages/tooling/module-sdk/modules/omni-account/ACCOUNT_LOCKER_SOURCE_EXECUTOR.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # ACCOUNT_LOCKER_SOURCE_EXECUTOR
 
 Returns the address of the module.

--- a/pages/tooling/module-sdk/modules/omni-account/ACCOUNT_LOCKER_TARGET_EXECUTOR.mdx
+++ b/pages/tooling/module-sdk/modules/omni-account/ACCOUNT_LOCKER_TARGET_EXECUTOR.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # ACCOUNT_LOCKER_TARGET_EXECUTOR
 
 Returns the address of the module.

--- a/pages/tooling/module-sdk/modules/omni-account/getAccountLockerHook.mdx
+++ b/pages/tooling/module-sdk/modules/omni-account/getAccountLockerHook.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAccountLockerHook
 
 Get the module installation data for the account locker hook. This hook enforces the resource locks on the account.

--- a/pages/tooling/module-sdk/modules/omni-account/getAccountLockerSourceExecutor.mdx
+++ b/pages/tooling/module-sdk/modules/omni-account/getAccountLockerSourceExecutor.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAccountLockerSourceExecutor
 
 Get the module installation data for the account locker source executor. This executor allows the solver to reclaim their fronted funds.

--- a/pages/tooling/module-sdk/modules/omni-account/getAccountLockerTargetExecutor.mdx
+++ b/pages/tooling/module-sdk/modules/omni-account/getAccountLockerTargetExecutor.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAccountLockerTargetExecutor
 
 Get the module installation data for the account locker target executor. This executor is used to execute the user action on the target chain.

--- a/pages/tooling/module-sdk/modules/omni-account/getDepositToAcrossAction.mdx
+++ b/pages/tooling/module-sdk/modules/omni-account/getDepositToAcrossAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getDepositToAcrossAction
 
 Get the action to deposit funds to across on the source chain. This is done after a target execution has been successfully completed.

--- a/pages/tooling/module-sdk/modules/omni-account/getRegisterApprovalSpendAction.mdx
+++ b/pages/tooling/module-sdk/modules/omni-account/getRegisterApprovalSpendAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # registerApprovalSpendAction
 
 Register an approval spend action on a resource locked account. This is useful for when the account is in omnilock mode and a user wants to make an approval.

--- a/pages/tooling/module-sdk/modules/omni-account/getUnlockFundsAction.mdx
+++ b/pages/tooling/module-sdk/modules/omni-account/getUnlockFundsAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getUnlockFundsAction
 
 Get the action to unlock funds on the source chain. This is done if a user wants to move funds out of the resource lock.

--- a/pages/tooling/module-sdk/modules/ownable-executor.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-executor.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Ownable Executor
 
 The Ownable Executor allows you to create a hierarchy ownership structure across smart accounts. This module allows one smart account to have execution rights on another smart account. The execution rights can trigger any transaction with the owner account paying for gas. This can enable automated relationships between DAOs and sub-DAOs or main accounts to sub-accounts.

--- a/pages/tooling/module-sdk/modules/ownable-executor/OWNABLE_EXECUTOR_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-executor/OWNABLE_EXECUTOR_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # OWNABLE_EXECUTOR_ADDRESS
 
 Returns the address of the module.

--- a/pages/tooling/module-sdk/modules/ownable-executor/getAddOwnableExecutorOwnerAction.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-executor/getAddOwnableExecutorOwnerAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAddOwnableExecutorOwnerAction
 
 Get the action to add an owner to the ownable executor.

--- a/pages/tooling/module-sdk/modules/ownable-executor/getExecuteBatchOnOwnedAccountAction.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-executor/getExecuteBatchOnOwnedAccountAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getExecuteBatchOnOwnedAccountAction
 
 Get the action to execute a batch of transactions on an owned account through the owner smart account.

--- a/pages/tooling/module-sdk/modules/ownable-executor/getExecuteOnOwnedAccountAction.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-executor/getExecuteOnOwnedAccountAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getExecuteOnOwnedAccountAction
 
 Get the action to execute a single action on the owned account from the owner smart account.

--- a/pages/tooling/module-sdk/modules/ownable-executor/getOwnableExecutor.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-executor/getOwnableExecutor.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getOwnableExecutor
 
 Get the ownable executor module object.

--- a/pages/tooling/module-sdk/modules/ownable-executor/getOwnableExecutorOwners.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-executor/getOwnableExecutorOwners.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getOwnableExecutorOwners
 
 Get the owners of the owned smart account.

--- a/pages/tooling/module-sdk/modules/ownable-executor/getRemoveOwnableExecutorOwnerAction.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-executor/getRemoveOwnableExecutorOwnerAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getRemoveOwnableExecutorOwnerAction
 
 Get the action to remove an owner from the ownable executor.

--- a/pages/tooling/module-sdk/modules/ownable-validator.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-validator.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Ownable Validator
 
 The Ownable Validator enables an EOA as a signer for a smart account. It is ideal for product use cases where users are expected to be crypto-native and possess an EOA wallet. Alternatively, it can be combined with MPC providers [embedded signers](https://docs.pimlico.io/permissionless/how-to/signers).

--- a/pages/tooling/module-sdk/modules/ownable-validator/OWNABLE_VALIDATOR_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-validator/OWNABLE_VALIDATOR_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # OWNABLE_VALIDATOR_ADDRESS
 
 Returns the address of the module.

--- a/pages/tooling/module-sdk/modules/ownable-validator/getAddOwnableValidatorOwnerAction.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-validator/getAddOwnableValidatorOwnerAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAddOwnableValidatorOwnerAction
 
 Get the action to add an owner to the ownable validator.

--- a/pages/tooling/module-sdk/modules/ownable-validator/getOwnableValidator.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-validator/getOwnableValidator.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getOwnableValidator
 
 Get the ownable validator module object.

--- a/pages/tooling/module-sdk/modules/ownable-validator/getOwnableValidatorMockSignature.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-validator/getOwnableValidatorMockSignature.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getOwnableValidatorMockSignature
 
 Get the mock signature for the ownable validator in order to use for ERC-4337 gas calculations.

--- a/pages/tooling/module-sdk/modules/ownable-validator/getOwnableValidatorOwners.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-validator/getOwnableValidatorOwners.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getOwnableValidatorOwners
 
 Get the current owners of the ownable validator.

--- a/pages/tooling/module-sdk/modules/ownable-validator/getOwnableValidatorSignature.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-validator/getOwnableValidatorSignature.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getOwnableValidatorSignature
 
 Format the signature to use the ownable validator.

--- a/pages/tooling/module-sdk/modules/ownable-validator/getOwnableValidatorThreshold.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-validator/getOwnableValidatorThreshold.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getOwnableValidatorThreshold
 
 Get the current threshold of the ownable validator.

--- a/pages/tooling/module-sdk/modules/ownable-validator/getRemoveOwnableValidatorOwnerAction.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-validator/getRemoveOwnableValidatorOwnerAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getRemoveOwnableValidatorOwnerAction
 
 Get the action to remove an owner from the ownable validator.

--- a/pages/tooling/module-sdk/modules/ownable-validator/getSetOwnableValidatorThresholdAction.mdx
+++ b/pages/tooling/module-sdk/modules/ownable-validator/getSetOwnableValidatorThresholdAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getSetOwnableValidatorThresholdAction
 
 Get the action to set the threshold for the ownable validator.

--- a/pages/tooling/module-sdk/modules/registry-hook.mdx
+++ b/pages/tooling/module-sdk/modules/registry-hook.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Registry Hook
 
 The Module Registry enforces security guarantees and standards when installing a module on a smart account. The Module Registry stores onchain security attestations made by independent auditors. When installing a new module on the account, the Module Registry Adapter queries the Module Registry and checks that pre-set security thresholds have been met.

--- a/pages/tooling/module-sdk/modules/registry-hook/REGISTRY_HOOK_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/modules/registry-hook/REGISTRY_HOOK_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # REGISTRY_HOOK_ADDRESS
 
 Returns the address of the module.

--- a/pages/tooling/module-sdk/modules/registry-hook/getRegistryHook.mdx
+++ b/pages/tooling/module-sdk/modules/registry-hook/getRegistryHook.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getRegistryHook
 
 Get the registry hook module object.

--- a/pages/tooling/module-sdk/modules/registry-hook/getSetRegistryAction.mdx
+++ b/pages/tooling/module-sdk/modules/registry-hook/getSetRegistryAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getSetRegistryAction
 
 Get the action to change the registry.

--- a/pages/tooling/module-sdk/modules/scheduled-orders.mdx
+++ b/pages/tooling/module-sdk/modules/scheduled-orders.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Scheduled Orders
 
 Scheduled Orders allows for automated token swaps to be triggered on a smart account. The user can create a schedule on which a relayer will execute the swaps based on some parameters, like frequency or number of repetitions.

--- a/pages/tooling/module-sdk/modules/scheduled-orders/SCHEDULED_ORDERS_EXECUTER_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/modules/scheduled-orders/SCHEDULED_ORDERS_EXECUTER_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # SCHEDULED_ORDERS_EXECUTOR_ADDRESS
 
 Returns the address of the module.

--- a/pages/tooling/module-sdk/modules/scheduled-orders/getCreateScheduledOrderAction.mdx
+++ b/pages/tooling/module-sdk/modules/scheduled-orders/getCreateScheduledOrderAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getCreateScheduledOrderAction
 
 Get the action to create a new scheduled order.

--- a/pages/tooling/module-sdk/modules/scheduled-orders/getExecuteScheduledOrderAction.mdx
+++ b/pages/tooling/module-sdk/modules/scheduled-orders/getExecuteScheduledOrderAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getExecuteScheduledOrderAction
 
 Get the action to execute a scheduled order. Note that this should be called by a relayer.

--- a/pages/tooling/module-sdk/modules/scheduled-orders/getScheduledOrdersExecutor.mdx
+++ b/pages/tooling/module-sdk/modules/scheduled-orders/getScheduledOrdersExecutor.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getScheduledOrdersExecutor
 
 Get the scheduled orders executor module object.

--- a/pages/tooling/module-sdk/modules/scheduled-orders/getSwapOrderData.mdx
+++ b/pages/tooling/module-sdk/modules/scheduled-orders/getSwapOrderData.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getSwapOrderData
 
 Get the data for the swap order to use when creating a new scheduled order.

--- a/pages/tooling/module-sdk/modules/scheduled-transfers.mdx
+++ b/pages/tooling/module-sdk/modules/scheduled-transfers.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Scheduled Transfers
 
 Scheduled Transfers allows for automated transfers to be triggered on a smart account. The user can create a schedule on which a relayer will execute the transfers based on some parameters, like frequency or number of repetitions.

--- a/pages/tooling/module-sdk/modules/scheduled-transfers/SCHEDULED_TRANSFERS_EXECUTER_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/modules/scheduled-transfers/SCHEDULED_TRANSFERS_EXECUTER_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # SCHEDULED_TRANSFERS_EXECUTOR_ADDRESS
 
 Returns the address of the module.

--- a/pages/tooling/module-sdk/modules/scheduled-transfers/getCreateScheduledTransferAction.mdx
+++ b/pages/tooling/module-sdk/modules/scheduled-transfers/getCreateScheduledTransferAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getCreateScheduledTransferAction
 
 Get the action to create a new scheduled transfer.

--- a/pages/tooling/module-sdk/modules/scheduled-transfers/getExecuteScheduledTransferAction.mdx
+++ b/pages/tooling/module-sdk/modules/scheduled-transfers/getExecuteScheduledTransferAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getExecuteScheduledTransferAction
 
 Get the action to execute a scheduled transfer. Note that this should be triggered by a relayer.

--- a/pages/tooling/module-sdk/modules/scheduled-transfers/getScheduledTransferData.mdx
+++ b/pages/tooling/module-sdk/modules/scheduled-transfers/getScheduledTransferData.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getScheduledTransferData
 
 Get the encoded data for a scheduled transfer.

--- a/pages/tooling/module-sdk/modules/scheduled-transfers/getScheduledTransfersExecutor.mdx
+++ b/pages/tooling/module-sdk/modules/scheduled-transfers/getScheduledTransfersExecutor.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getScheduledTransfersExecutor
 
 description

--- a/pages/tooling/module-sdk/modules/scheduled-transfers/getToggleScheduledTransferAction.mdx
+++ b/pages/tooling/module-sdk/modules/scheduled-transfers/getToggleScheduledTransferAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getToggleScheduledTransferAction
 
 Get the action to toggle a scheduled transfer between active and inactive.

--- a/pages/tooling/module-sdk/modules/smart-sessions.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Smart Sessions
 
 Smart Sessions allows developers to use session keys with any ERC-7579 smart account. It further combines granular permissions with session keys in the form of policies, which restrict what the key is allowed to do.

--- a/pages/tooling/module-sdk/modules/smart-sessions/SMART_SESSIONS_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/SMART_SESSIONS_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # SMART_SESSIONS_ADDRESS
 
 Returns the address of the module.

--- a/pages/tooling/module-sdk/modules/smart-sessions/decodeSmartSessionSignature.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/decodeSmartSessionSignature.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # decodeSmartSessionSignature
 
 Get decoded session from SmartSessionSignature.

--- a/pages/tooling/module-sdk/modules/smart-sessions/encodeSmartSessionSignature.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/encodeSmartSessionSignature.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # encodeSmartSessionSignature
 
 Get encoded smart session signature.

--- a/pages/tooling/module-sdk/modules/smart-sessions/encodeUseOrEnableSmartSessionSignature.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/encodeUseOrEnableSmartSessionSignature.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # encodeUseOrEnableSmartSessionSignature
 
 Get encoded smart session signature.

--- a/pages/tooling/module-sdk/modules/smart-sessions/getActionId.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/getActionId.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getActionId
 
 Get the action ID for a specific action.

--- a/pages/tooling/module-sdk/modules/smart-sessions/getDisableActionPoliciesAction.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/getDisableActionPoliciesAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getDisableActionPoliciesAction
 
 Get the action to disable action policies for a specific session in the smart sessions validator.

--- a/pages/tooling/module-sdk/modules/smart-sessions/getDisableERC1271PoliciesAction.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/getDisableERC1271PoliciesAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getDisableERC1271PoliciesAction
 
 Get the action to disable ERC1271 policies for a specific session in the smart sessions validator.

--- a/pages/tooling/module-sdk/modules/smart-sessions/getDisableUserOpPoliciesAction.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/getDisableUserOpPoliciesAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getDisableUserOpPoliciesAction
 
 Get the action to disable userOp policies for a specific session in the smart sessions validator.

--- a/pages/tooling/module-sdk/modules/smart-sessions/getEnableActionPoliciesAction.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/getEnableActionPoliciesAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getEnableActionPoliciesAction
 
 Get the action to enable action policies for a specific session in the smart sessions validator.

--- a/pages/tooling/module-sdk/modules/smart-sessions/getEnableERC1271PoliciesAction.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/getEnableERC1271PoliciesAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getEnableERC1271PoliciesAction
 
 Get the action to enable ERC1271 policies for a specific session in the smart sessions validator.

--- a/pages/tooling/module-sdk/modules/smart-sessions/getEnableSessionDetails.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/getEnableSessionDetails.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getEnableSessionDetails
 
 This method is used to get the details for a new session to enable through the `enable` flow. It abstracts away the different steps required and makes to easier when wanting to enable a new session without custom logic.

--- a/pages/tooling/module-sdk/modules/smart-sessions/getEnableSessionsAction.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/getEnableSessionsAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getEnableSessionsAction
 
 Get the action to enable new sessions on smart sessions. Note that this action cannot be used to change an existing session, but only to create new ones.

--- a/pages/tooling/module-sdk/modules/smart-sessions/getEnableUserOpPoliciesAction.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/getEnableUserOpPoliciesAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getEnableUserOpPoliciesAction
 
 Get the action to enable userOp policies for a specific session in the smart sessions validator.

--- a/pages/tooling/module-sdk/modules/smart-sessions/getPermissionId.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/getPermissionId.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getPermissionId
 
 Get the permission ID of a session.

--- a/pages/tooling/module-sdk/modules/smart-sessions/getPermissions.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/getPermissions.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getPermissions
 
 This function leverages [ERC-7715](https://github.com/ethereum/ERCs/pull/436/) and allows a client to transform 7715 permission objects into policies for [Smart Sessions](/tooling/module-sdk/modules/smart-sessions).

--- a/pages/tooling/module-sdk/modules/smart-sessions/getRemoveSessionAction.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/getRemoveSessionAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getRemoveSessionAction
 
 Get the action to remove a session from the smart sessions validator.

--- a/pages/tooling/module-sdk/modules/smart-sessions/getSessionDigest.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/getSessionDigest.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getSessionDigest
 
 Get digest of a session.

--- a/pages/tooling/module-sdk/modules/smart-sessions/getSessionNonce.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/getSessionNonce.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getSessionNonce
 
 Get the nonce of a session.

--- a/pages/tooling/module-sdk/modules/smart-sessions/getSmartSessionsValidator.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/getSmartSessionsValidator.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getSmartSessionsValidator
 
 Get the smart sessions module object.

--- a/pages/tooling/module-sdk/modules/smart-sessions/hashChainSessions.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/hashChainSessions.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # hashChainSessions
 
 Hash a list of chain sessions.

--- a/pages/tooling/module-sdk/modules/smart-sessions/isSessionEnabled.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/isSessionEnabled.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # isSessionEnabled
 
 Check whether a session is enabled or not.

--- a/pages/tooling/module-sdk/modules/smart-sessions/policies/getSpendingLimitsPolicy.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/policies/getSpendingLimitsPolicy.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getSpendingLimitsPolicy
 
 Get the spending limits policy to use when creating a new session. The spending limits policy can be used to ensure that only a certain amount of ERC-20 tokens can be spent. For native value spends, use the value limit policy.

--- a/pages/tooling/module-sdk/modules/smart-sessions/policies/getSudoPolicy.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/policies/getSudoPolicy.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getSudoPolicy
 
 Get the sudo policy to be used when creating a new session. The sudo policy is an action policy that will allow any action for the specified target and selector.

--- a/pages/tooling/module-sdk/modules/smart-sessions/policies/getTimeFramePolicy.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/policies/getTimeFramePolicy.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getTimeFramePolicy
 
 Get the timeframe policy to use when creating a new session. The timeframe policy can be used to restrict a session to only be able to be used within a certain timeframe.

--- a/pages/tooling/module-sdk/modules/smart-sessions/policies/getUniversalActionPolicy.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/policies/getUniversalActionPolicy.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getUniversalActionPolicy
 
 Get the universal action policy to use when creating a new session. The universal action policy can be used to ensure that only actions where the calldata has certain parameters can be used. For example, it could restrict swaps on Uniswap to be only under X amount of input token.

--- a/pages/tooling/module-sdk/modules/smart-sessions/policies/getUsageLimitPolicy.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/policies/getUsageLimitPolicy.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getUsageLimitPolicy
 
 Get the usage limits policy to use when creating a new session. The usage limit policy is used to restrict a sesion to only be able to be used a certain number of times.

--- a/pages/tooling/module-sdk/modules/smart-sessions/policies/getValueLimitPolicy.mdx
+++ b/pages/tooling/module-sdk/modules/smart-sessions/policies/getValueLimitPolicy.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getValueLimitPolicy
 
 Get the value limit policy to use when creating a new session. The value limit policy can be used to enforce that only a certain amount of native value can be spent. For ERC-20 limits, use the spending limit policy.

--- a/pages/tooling/module-sdk/modules/social-recovery.mdx
+++ b/pages/tooling/module-sdk/modules/social-recovery.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Social Recovery
 
 Social Recovery allows users to specify one or multiple guardians with an m or n threshold for account recovery. The user sets a guardian by expressing the public address of the guardian.

--- a/pages/tooling/module-sdk/modules/social-recovery/SOCIAL_RECOVERY_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/modules/social-recovery/SOCIAL_RECOVERY_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # SOCIAL_RECOVERY_ADDRESS
 
 Returns the address of the module.

--- a/pages/tooling/module-sdk/modules/social-recovery/getAddSocialRecoveryGuardianAction.mdx
+++ b/pages/tooling/module-sdk/modules/social-recovery/getAddSocialRecoveryGuardianAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getAddSocialRecoveryGuardianAction
 
 Get the action to add a social recovery guardian for an account.

--- a/pages/tooling/module-sdk/modules/social-recovery/getRemoveSocialRecoveryGuardianAction.mdx
+++ b/pages/tooling/module-sdk/modules/social-recovery/getRemoveSocialRecoveryGuardianAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getRemoveSocialRecoveryGuardianAction
 
 Get the action to remove a social recovery guardian for an account.

--- a/pages/tooling/module-sdk/modules/social-recovery/getSetSocialRecoveryThresholdAction.mdx
+++ b/pages/tooling/module-sdk/modules/social-recovery/getSetSocialRecoveryThresholdAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getSetSocialRecoveryThresholdAction
 
 Get the action to set the social recovery threshold for an account.

--- a/pages/tooling/module-sdk/modules/social-recovery/getSocialRecoveryGuardians.mdx
+++ b/pages/tooling/module-sdk/modules/social-recovery/getSocialRecoveryGuardians.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getSocialRecoveryGuardians
 
 description

--- a/pages/tooling/module-sdk/modules/social-recovery/getSocialRecoveryMockSignature.mdx
+++ b/pages/tooling/module-sdk/modules/social-recovery/getSocialRecoveryMockSignature.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getSocialRecoveryMockSignature
 
 Get the mock signature for the social recovery in order to use for ERC-4337 gas calculations.

--- a/pages/tooling/module-sdk/modules/social-recovery/getSocialRecoveryValidator.mdx
+++ b/pages/tooling/module-sdk/modules/social-recovery/getSocialRecoveryValidator.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getSocialRecoveryValidator
 
 Get the social recovery validator module object.

--- a/pages/tooling/module-sdk/modules/webauthn-validator.mdx
+++ b/pages/tooling/module-sdk/modules/webauthn-validator.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # Webauthn Validator
 
 The Webauthn Validator enables a passkey as a signer on a smart account, allowing users to sign cryptographic messages with their biometrics via the secure enclave of their device or use a preferred password manager.

--- a/pages/tooling/module-sdk/modules/webauthn-validator/WEBAUTHN_VALIDATOR_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/modules/webauthn-validator/WEBAUTHN_VALIDATOR_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # WEBAUTHN_VALIDATOR_ADDRESS
 
 Returns the address of the module.

--- a/pages/tooling/module-sdk/modules/webauthn-validator/getWebAuthnValidator.mdx
+++ b/pages/tooling/module-sdk/modules/webauthn-validator/getWebAuthnValidator.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getWebAuthnValidator
 
 Get the WebAuthn validator module object.

--- a/pages/tooling/module-sdk/modules/webauthn-validator/getWebauthnValidatorMockSignature.mdx
+++ b/pages/tooling/module-sdk/modules/webauthn-validator/getWebauthnValidatorMockSignature.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getWebauthnValidatorMockSignature
 
 Get the mock signature for the WebAuthn validator in order to use for ERC-4337 gas calculations.

--- a/pages/tooling/module-sdk/modules/webauthn-validator/getWebauthnValidatorSignature.mdx
+++ b/pages/tooling/module-sdk/modules/webauthn-validator/getWebauthnValidatorSignature.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getWebauthnValidatorSignature
 
 Get the encoded signature for the WebAuthn validator.

--- a/pages/tooling/module-sdk/registry/MOCK_ATTESTER_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/registry/MOCK_ATTESTER_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # MOCK_ATTESTER_ADDRESS
 
 Returns the address of the mock attester. Note that this mock attester is only meant for testing purposes and only exists on tesntets.

--- a/pages/tooling/module-sdk/registry/REGISTRY_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/registry/REGISTRY_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # REGISTRY_ADDRESS
 
 Returns the address of the Registry.

--- a/pages/tooling/module-sdk/registry/RHINESTONE_ATTESTER_ADDRESS.mdx
+++ b/pages/tooling/module-sdk/registry/RHINESTONE_ATTESTER_ADDRESS.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # RHINESTONE_ATTESTER_ADDRESS
 
 Returns the address of the Rhinestone attester. Trusting this attester on the Registry, allows users to use any module that has been attested by Rhinestone.

--- a/pages/tooling/module-sdk/registry/getRegistryModules.mdx
+++ b/pages/tooling/module-sdk/registry/getRegistryModules.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getRegistryModules
 
 Gets all modules registered on the [Module Registry](/module-registry).

--- a/pages/tooling/module-sdk/registry/getTrustAttestersAction.mdx
+++ b/pages/tooling/module-sdk/registry/getTrustAttestersAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getTrustAttestersAction
 
 Gets the action to have a user trust a set of attesters on the Registry.

--- a/pages/tooling/module-sdk/tutorial-1.mdx
+++ b/pages/tooling/module-sdk/tutorial-1.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 import { Steps } from 'nextra/components'
 
 # Tutorial 1: Install and use your first module

--- a/pages/tooling/module-sdk/using-modules/deadman-switch.mdx
+++ b/pages/tooling/module-sdk/using-modules/deadman-switch.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 import { Steps } from 'nextra/components'
 
 # How to secure and recovery an account using the Deadman Switch Module

--- a/pages/tooling/module-sdk/using-modules/smart-sessions.mdx
+++ b/pages/tooling/module-sdk/using-modules/smart-sessions.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 import { Steps } from 'nextra/components'
 
 # How to use session keys using Smart Sessions

--- a/pages/tooling/module-sdk/using-modules/social-recovery.mdx
+++ b/pages/tooling/module-sdk/using-modules/social-recovery.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 import { Steps } from 'nextra/components'
 
 # How to recover an account using the Social Recovery Module

--- a/pages/tooling/module-sdk/using-modules/webauthn.mdx
+++ b/pages/tooling/module-sdk/using-modules/webauthn.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 import { Steps } from 'nextra/components'
 
 # How to use passkeys to control an account

--- a/pages/tooling/module-sdk/utilities/getClient.mdx
+++ b/pages/tooling/module-sdk/utilities/getClient.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleSDK was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # getClient
 
 Gets an rpc client to use for a given chain. This is a wrapper around viem's `PublicClient`.

--- a/pages/tooling/modulekit/erc4337-validation/getting-started.mdx
+++ b/pages/tooling/modulekit/erc4337-validation/getting-started.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "Getting started"
 ---

--- a/pages/tooling/modulekit/erc4337-validation/overview.mdx
+++ b/pages/tooling/modulekit/erc4337-validation/overview.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "Overview"
 ---

--- a/pages/tooling/modulekit/erc4337-validation/simulator/simulateUserOp.mdx
+++ b/pages/tooling/modulekit/erc4337-validation/simulator/simulateUserOp.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "simulateUserOp"
 ---

--- a/pages/tooling/modulekit/getting-started.mdx
+++ b/pages/tooling/modulekit/getting-started.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "Getting Started"
 ---

--- a/pages/tooling/modulekit/guides/deploying/deploying-modules.mdx
+++ b/pages/tooling/modulekit/guides/deploying/deploying-modules.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "How to use ModuleKit to deploy modules"
 sidebarTitle: "Deploying Modules"

--- a/pages/tooling/modulekit/guides/migration-guide.mdx
+++ b/pages/tooling/modulekit/guides/migration-guide.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "Migration Guide"
 ---

--- a/pages/tooling/modulekit/guides/testing/calculating-gas.mdx
+++ b/pages/tooling/modulekit/guides/testing/calculating-gas.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "How to use ModuleKit to calculate gas consumption of modules"
 sidebarTitle: "Calculating Gas"

--- a/pages/tooling/modulekit/guides/testing/erc7579-compliance.mdx
+++ b/pages/tooling/modulekit/guides/testing/erc7579-compliance.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "How to use ModuleKit to test for ERC-7579 compliance"
 sidebarTitle: "ERC-7579 Compliance"

--- a/pages/tooling/modulekit/guides/testing/simulating-userops.mdx
+++ b/pages/tooling/modulekit/guides/testing/simulating-userops.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "How to use ModuleKit to test ERC-4337 restrictions"
 sidebarTitle: "Simulating UserOps"

--- a/pages/tooling/modulekit/guides/testing/using-accounts.mdx
+++ b/pages/tooling/modulekit/guides/testing/using-accounts.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "How to use ModuleKit with different accounts"
 sidebarTitle: "Using Accounts"
@@ -32,4 +39,3 @@ where the options are:
 - `KERNEL`: The Kernel account
 - `NEXUS`: The Nexus account
 - `CUSTOM`: A custom account
-

--- a/pages/tooling/modulekit/index.mdx
+++ b/pages/tooling/modulekit/index.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 # ModuleKit
 
 **A development kit for building smart account modules**

--- a/pages/tooling/modulekit/module-registry/getting-started.mdx
+++ b/pages/tooling/modulekit/module-registry/getting-started.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "Getting Started"
 ---

--- a/pages/tooling/modulekit/module-registry/glossary/types.mdx
+++ b/pages/tooling/modulekit/module-registry/glossary/types.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "Glossary"
 ---

--- a/pages/tooling/modulekit/module-registry/integrations/account.mdx
+++ b/pages/tooling/modulekit/module-registry/integrations/account.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "How to integrate the Registry into a smart account"
 sidebarTitle: "Account"

--- a/pages/tooling/modulekit/module-registry/integrations/wallet.mdx
+++ b/pages/tooling/modulekit/module-registry/integrations/wallet.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "How to integrate the Registry into a smart wallet"
 sidebarTitle: "Wallet"

--- a/pages/tooling/modulekit/module-registry/modules/calcModuleAddress.mdx
+++ b/pages/tooling/modulekit/module-registry/modules/calcModuleAddress.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "calcModuleAddress"
 ---

--- a/pages/tooling/modulekit/module-registry/modules/deployModule.mdx
+++ b/pages/tooling/modulekit/module-registry/modules/deployModule.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "deployModule"
 ---

--- a/pages/tooling/modulekit/module-registry/modules/deployViaFactory.mdx
+++ b/pages/tooling/modulekit/module-registry/modules/deployViaFactory.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "deployViaFactory"
 ---

--- a/pages/tooling/modulekit/module-registry/modules/findModule.mdx
+++ b/pages/tooling/modulekit/module-registry/modules/findModule.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "findModule"
 ---

--- a/pages/tooling/modulekit/module-registry/modules/registerModule.mdx
+++ b/pages/tooling/modulekit/module-registry/modules/registerModule.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "registerModule"
 ---

--- a/pages/tooling/modulekit/module-registry/overview.mdx
+++ b/pages/tooling/modulekit/module-registry/overview.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "Overview"
 ---

--- a/pages/tooling/modulekit/module-registry/querying/check.mdx
+++ b/pages/tooling/modulekit/module-registry/querying/check.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "check"
 ---

--- a/pages/tooling/modulekit/module-registry/querying/checkForAccount.mdx
+++ b/pages/tooling/modulekit/module-registry/querying/checkForAccount.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "checkForAccount"
 ---

--- a/pages/tooling/modulekit/module-registry/querying/findTrustedAttesters.mdx
+++ b/pages/tooling/modulekit/module-registry/querying/findTrustedAttesters.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "findTrustedAttesters"
 ---

--- a/pages/tooling/modulekit/module-registry/querying/trustAttesters.mdx
+++ b/pages/tooling/modulekit/module-registry/querying/trustAttesters.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "trustAttesters"
 ---

--- a/pages/tooling/modulekit/module-registry/usage/mock-attestation.mdx
+++ b/pages/tooling/modulekit/module-registry/usage/mock-attestation.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "How to make a mock attestation to use a module on testnet"
 sidebarTitle: "Mock Attestation"

--- a/pages/tooling/modulekit/reference/building/core/isInitialized.mdx
+++ b/pages/tooling/modulekit/reference/building/core/isInitialized.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "isInitialized"
 ---

--- a/pages/tooling/modulekit/reference/building/core/isModuleType.mdx
+++ b/pages/tooling/modulekit/reference/building/core/isModuleType.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "isModuleType"
 ---

--- a/pages/tooling/modulekit/reference/building/core/name.mdx
+++ b/pages/tooling/modulekit/reference/building/core/name.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "name"
 ---

--- a/pages/tooling/modulekit/reference/building/core/onInstall.mdx
+++ b/pages/tooling/modulekit/reference/building/core/onInstall.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "onInstall"
 ---

--- a/pages/tooling/modulekit/reference/building/core/onUninstall.mdx
+++ b/pages/tooling/modulekit/reference/building/core/onUninstall.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "onUninstall"
 ---

--- a/pages/tooling/modulekit/reference/building/core/version.mdx
+++ b/pages/tooling/modulekit/reference/building/core/version.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "version"
 ---

--- a/pages/tooling/modulekit/reference/building/executors/execute.mdx
+++ b/pages/tooling/modulekit/reference/building/executors/execute.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "execute"
 ---

--- a/pages/tooling/modulekit/reference/building/executors/executeDelegateCall.mdx
+++ b/pages/tooling/modulekit/reference/building/executors/executeDelegateCall.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "_executeDelegateCall"
 ---

--- a/pages/tooling/modulekit/reference/building/fallbacks/msgSender.mdx
+++ b/pages/tooling/modulekit/reference/building/fallbacks/msgSender.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "_msgSender"
 ---

--- a/pages/tooling/modulekit/reference/building/hooks/onExecute.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/onExecute.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "onExecute"
 ---

--- a/pages/tooling/modulekit/reference/building/hooks/onExecuteBatch.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/onExecuteBatch.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "onExecuteBatch"
 ---

--- a/pages/tooling/modulekit/reference/building/hooks/onExecuteBatchFromExecutor.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/onExecuteBatchFromExecutor.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "onExecuteBatchFromExecutor"
 ---

--- a/pages/tooling/modulekit/reference/building/hooks/onExecuteFromExecutor.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/onExecuteFromExecutor.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "onExecuteFromExecutor"
 ---

--- a/pages/tooling/modulekit/reference/building/hooks/onInstallModule.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/onInstallModule.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "onInstallModule"
 ---

--- a/pages/tooling/modulekit/reference/building/hooks/onPostCheck.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/onPostCheck.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "onPostCheck"
 ---

--- a/pages/tooling/modulekit/reference/building/hooks/onUninstallModule.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/onUninstallModule.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "onUninstallModule"
 ---

--- a/pages/tooling/modulekit/reference/building/hooks/onUnknownFunction.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/onUnknownFunction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "onUnknownFunction"
 ---

--- a/pages/tooling/modulekit/reference/building/hooks/postCheck.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/postCheck.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "_postCheck"
 ---

--- a/pages/tooling/modulekit/reference/building/hooks/preCheck.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/preCheck.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "_preCheck"
 ---

--- a/pages/tooling/modulekit/reference/building/registry-adapter/registry.mdx
+++ b/pages/tooling/modulekit/reference/building/registry-adapter/registry.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "REGISTRY"
 sidebarTitle: "Registry"

--- a/pages/tooling/modulekit/reference/building/scheduling-module/executeOrder.mdx
+++ b/pages/tooling/modulekit/reference/building/scheduling-module/executeOrder.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "executeOrder"
 ---

--- a/pages/tooling/modulekit/reference/building/smart-sessions/check1271SignedAction.mdx
+++ b/pages/tooling/modulekit/reference/building/smart-sessions/check1271SignedAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "check1271SignedAction"
 ---

--- a/pages/tooling/modulekit/reference/building/smart-sessions/checkAction.mdx
+++ b/pages/tooling/modulekit/reference/building/smart-sessions/checkAction.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "checkAction"
 ---

--- a/pages/tooling/modulekit/reference/building/smart-sessions/checkUserOp.mdx
+++ b/pages/tooling/modulekit/reference/building/smart-sessions/checkUserOp.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "checkUserOp"
 ---

--- a/pages/tooling/modulekit/reference/building/smart-sessions/initializeWithMultiplexer.mdx
+++ b/pages/tooling/modulekit/reference/building/smart-sessions/initializeWithMultiplexer.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "initializeWithMultiplexer"
 ---

--- a/pages/tooling/modulekit/reference/building/trusted-forwarder/getAccount.mdx
+++ b/pages/tooling/modulekit/reference/building/trusted-forwarder/getAccount.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "_getAccount"
 ---

--- a/pages/tooling/modulekit/reference/building/validators/isValidSignatureWithSender.mdx
+++ b/pages/tooling/modulekit/reference/building/validators/isValidSignatureWithSender.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "isValidSignatureWithSender"
 ---

--- a/pages/tooling/modulekit/reference/building/validators/packValidationData.mdx
+++ b/pages/tooling/modulekit/reference/building/validators/packValidationData.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "_packValidationData"
 ---

--- a/pages/tooling/modulekit/reference/building/validators/unpackValidationData.mdx
+++ b/pages/tooling/modulekit/reference/building/validators/unpackValidationData.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "_unpackValidationData"
 ---

--- a/pages/tooling/modulekit/reference/building/validators/validateUserOp.mdx
+++ b/pages/tooling/modulekit/reference/building/validators/validateUserOp.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "validateUserOp"
 ---

--- a/pages/tooling/modulekit/reference/checknsignatures/checknsignaturesfoundryhelper/sign.mdx
+++ b/pages/tooling/modulekit/reference/checknsignatures/checknsignaturesfoundryhelper/sign.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "sign"
 ---

--- a/pages/tooling/modulekit/reference/checknsignatures/checksignatures/recoverNSignatures.mdx
+++ b/pages/tooling/modulekit/reference/checknsignatures/checksignatures/recoverNSignatures.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "recoverNSignatures"
 ---

--- a/pages/tooling/modulekit/reference/deploying/attestations/isModuleAttestedMock.mdx
+++ b/pages/tooling/modulekit/reference/deploying/attestations/isModuleAttestedMock.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "isModuleAttestedMock"
 ---

--- a/pages/tooling/modulekit/reference/deploying/attestations/mockAttestToModule.mdx
+++ b/pages/tooling/modulekit/reference/deploying/attestations/mockAttestToModule.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "mockAttestToModule"
 ---

--- a/pages/tooling/modulekit/reference/deploying/core/deployModule.mdx
+++ b/pages/tooling/modulekit/reference/deploying/core/deployModule.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "deployModule"
 ---

--- a/pages/tooling/modulekit/reference/deploying/core/deployModuleViaFactory.mdx
+++ b/pages/tooling/modulekit/reference/deploying/core/deployModuleViaFactory.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "deployModuleViaFactory"
 ---

--- a/pages/tooling/modulekit/reference/deploying/core/predictModuleAddress.mdx
+++ b/pages/tooling/modulekit/reference/deploying/core/predictModuleAddress.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "predictModuleAddress"
 ---

--- a/pages/tooling/modulekit/reference/deploying/core/registerModule.mdx
+++ b/pages/tooling/modulekit/reference/deploying/core/registerModule.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "registerModule"
 ---

--- a/pages/tooling/modulekit/reference/deploying/registry/findModule.mdx
+++ b/pages/tooling/modulekit/reference/deploying/registry/findModule.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "findModule"
 ---

--- a/pages/tooling/modulekit/reference/deploying/registry/findResolver.mdx
+++ b/pages/tooling/modulekit/reference/deploying/registry/findResolver.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "findResolver"
 ---

--- a/pages/tooling/modulekit/reference/deploying/registry/findSchema.mdx
+++ b/pages/tooling/modulekit/reference/deploying/registry/findSchema.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "findSchema"
 ---

--- a/pages/tooling/modulekit/reference/deploying/registry/registerResolver.mdx
+++ b/pages/tooling/modulekit/reference/deploying/registry/registerResolver.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "registerResolver"
 ---

--- a/pages/tooling/modulekit/reference/deploying/registry/registerSchema.mdx
+++ b/pages/tooling/modulekit/reference/deploying/registry/registerSchema.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "registerSchema"
 ---

--- a/pages/tooling/modulekit/reference/deploying/registry/setRegistry.mdx
+++ b/pages/tooling/modulekit/reference/deploying/registry/setRegistry.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "setRegistry"
 ---

--- a/pages/tooling/modulekit/reference/deploying/registry/setResolverUID.mdx
+++ b/pages/tooling/modulekit/reference/deploying/registry/setResolverUID.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "setResolverUID"
 ---

--- a/pages/tooling/modulekit/reference/deploying/registry/setSchemaUID.mdx
+++ b/pages/tooling/modulekit/reference/deploying/registry/setSchemaUID.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "setSchemaUID"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/flatbytes/flatbyteslib/clear.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/flatbytes/flatbyteslib/clear.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "clear"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/flatbytes/flatbyteslib/load.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/flatbytes/flatbyteslib/load.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "load"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/flatbytes/flatbyteslib/store.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/flatbytes/flatbyteslib/store.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "store"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/alreadyInitialized.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/alreadyInitialized.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "alreadyInitialized"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/contains.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/contains.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "contains"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/getEntriesPaginated.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/getEntriesPaginated.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "getEntriesPaginated"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/getNext.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/getNext.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "getNext"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/init.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/init.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "init"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/pop.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/pop.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "pop"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/popAll.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/popAll.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "popAll"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/push.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/push.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "push"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/safePush.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/safePush.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "safePush"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/alreadyInitialized.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/alreadyInitialized.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "alreadyInitialized"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/contains.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/contains.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "contains"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/getEntriesPaginated.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/getEntriesPaginated.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "getEntriesPaginated"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/getNext.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/getNext.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "getNext"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/init.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/init.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "init"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/pop.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/pop.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "pop"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/popAll.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/popAll.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "popAll"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/push.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/push.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "push"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/safePush.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/safePush.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "safePush"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellisthelper/findPrevious.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellisthelper/findPrevious.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "findPrevious"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/alreadyInitialized.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/alreadyInitialized.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "alreadyInitialized"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/contains.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/contains.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "contains"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/getEntriesPaginated.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/getEntriesPaginated.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "getEntriesPaginated"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/getNext.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/getNext.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "getNext"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/init.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/init.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "init"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/pop.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/pop.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "pop"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/popAll.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/popAll.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "popAll"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/push.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/push.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "push"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/safePush.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/safePush.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "safePush"
 ---

--- a/pages/tooling/modulekit/reference/erc4337-validation/simulator/simulateUserOp.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-validation/simulator/simulateUserOp.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "simulateUserOp"
 ---

--- a/pages/tooling/modulekit/reference/glossary/types.mdx
+++ b/pages/tooling/modulekit/reference/glossary/types.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "Types in ModuleKit"
 sidebarTitle: "Glossary"

--- a/pages/tooling/modulekit/reference/testing/core/exec.mdx
+++ b/pages/tooling/modulekit/reference/testing/core/exec.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "exec"
 ---

--- a/pages/tooling/modulekit/reference/testing/core/execUserOps.mdx
+++ b/pages/tooling/modulekit/reference/testing/core/execUserOps.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "execUserOps"
 ---

--- a/pages/tooling/modulekit/reference/testing/core/getExecOps.mdx
+++ b/pages/tooling/modulekit/reference/testing/core/getExecOps.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "getExecOps"
 ---

--- a/pages/tooling/modulekit/reference/testing/core/makeAccountInstance.mdx
+++ b/pages/tooling/modulekit/reference/testing/core/makeAccountInstance.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "makeAccountInstance"
 ---

--- a/pages/tooling/modulekit/reference/testing/modules/getInstalledModules.mdx
+++ b/pages/tooling/modulekit/reference/testing/modules/getInstalledModules.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "getInstalledModules"
 ---

--- a/pages/tooling/modulekit/reference/testing/modules/installModule.mdx
+++ b/pages/tooling/modulekit/reference/testing/modules/installModule.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "installModule"
 ---

--- a/pages/tooling/modulekit/reference/testing/modules/isModuleInstalled.mdx
+++ b/pages/tooling/modulekit/reference/testing/modules/isModuleInstalled.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "isModuleInstalled"
 ---

--- a/pages/tooling/modulekit/reference/testing/modules/uninstallModule.mdx
+++ b/pages/tooling/modulekit/reference/testing/modules/uninstallModule.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "uninstallModule"
 ---

--- a/pages/tooling/modulekit/reference/testing/signature-validation/formatERC1271Hash.mdx
+++ b/pages/tooling/modulekit/reference/testing/signature-validation/formatERC1271Hash.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "formatERC1271Hash"
 ---

--- a/pages/tooling/modulekit/reference/testing/signature-validation/formatERC1271Signature.mdx
+++ b/pages/tooling/modulekit/reference/testing/signature-validation/formatERC1271Signature.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "formatERC1271Signature"
 ---

--- a/pages/tooling/modulekit/reference/testing/signature-validation/isValidSignature.mdx
+++ b/pages/tooling/modulekit/reference/testing/signature-validation/isValidSignature.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "isValidSignature"
 ---

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/addSession.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/addSession.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "addSession"
 ---

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/encodeSignature.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/encodeSignature.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "encodeSignature"
 ---

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/getPermissionId.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/getPermissionId.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "getPermissionId"
 ---

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/getSessionDigest.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/getSessionDigest.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "getSessionDigest"
 ---

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/getSessionNonce.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/getSessionNonce.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "getSessionNonce"
 ---

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/isPermissionEnabled.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/isPermissionEnabled.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "isPermissionEnabled"
 ---

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/isSessionEnabled.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/isSessionEnabled.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "isSessionEnabled"
 ---

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/makeMultiChainEnableData.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/makeMultiChainEnableData.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "makeMultiChainEnableData"
 ---

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/removeSession.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/removeSession.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "removeSession"
 ---

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/useSession.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/useSession.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "useSession"
 ---

--- a/pages/tooling/modulekit/reference/testing/utilities/deployAccount.mdx
+++ b/pages/tooling/modulekit/reference/testing/utilities/deployAccount.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "deployAccount"
 ---

--- a/pages/tooling/modulekit/reference/testing/utilities/expect4337Revert.mdx
+++ b/pages/tooling/modulekit/reference/testing/utilities/expect4337Revert.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "expect4337Revert"
 ---

--- a/pages/tooling/modulekit/reference/testing/utilities/log4337Gas.mdx
+++ b/pages/tooling/modulekit/reference/testing/utilities/log4337Gas.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "log4337Gas"
 ---

--- a/pages/tooling/modulekit/reference/testing/utilities/setAccountEnv.mdx
+++ b/pages/tooling/modulekit/reference/testing/utilities/setAccountEnv.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "setAccountEnv"
 ---

--- a/pages/tooling/modulekit/reference/testing/utilities/simulateUserOp.mdx
+++ b/pages/tooling/modulekit/reference/testing/utilities/simulateUserOp.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "simulateUserOp"
 ---

--- a/pages/tooling/modulekit/reference/testing/utilities/withModuleStorageClearValidation.mdx
+++ b/pages/tooling/modulekit/reference/testing/utilities/withModuleStorageClearValidation.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "withModuleStorageClearValidation"
 ---

--- a/pages/tooling/modulekit/tutorials/auto-swap-executor.mdx
+++ b/pages/tooling/modulekit/tutorials/auto-swap-executor.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "Tutorial 2: Building an Auto-swap Executor"
 sidebarTitle: "Auto-Swap Executor"

--- a/pages/tooling/modulekit/tutorials/multi-owner-validator.mdx
+++ b/pages/tooling/modulekit/tutorials/multi-owner-validator.mdx
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecation Notice**
+>
+> ModuleKit was developed by Rhinestone and is no longer actively supported. 
+> For new projects, we recommend using the **Rhinestone SDK** instead.
+>
+> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+
 ---
 title: "Tutorial 1: Building a Muti-Owner Validator"
 sidebarTitle: "Multi-Owner Validator"


### PR DESCRIPTION
## Summary

- Add deprecation disclaimer to all ModuleSDK pages (187 files)
- Add deprecation disclaimer to all ModuleKit pages (134 files)
- Add Rhinestone SDK link to tooling overview page (listed first under Application developers)

## Context

ModuleSDK and ModuleKit were developed by Rhinestone and are no longer actively supported. This PR adds prominent deprecation notices directing developers to use the [Rhinestone SDK](https://docs.rhinestone.dev) instead.

## Test plan

- [ ] Verify disclaimers render correctly on ModuleSDK pages
- [ ] Verify disclaimers render correctly on ModuleKit pages
- [ ] Verify Rhinestone SDK link appears on tooling overview page

🤖 Generated with [Claude Code](https://claude.com/claude-code)