### PR TITLE
fix: update ModuleKit disclaimer to remove SDK link

### DIFF
--- a/pages/tooling/modulekit/erc4337-validation/getting-started.mdx
+++ b/pages/tooling/modulekit/erc4337-validation/getting-started.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "Getting started"

--- a/pages/tooling/modulekit/erc4337-validation/overview.mdx
+++ b/pages/tooling/modulekit/erc4337-validation/overview.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "Overview"

--- a/pages/tooling/modulekit/erc4337-validation/simulator/simulateUserOp.mdx
+++ b/pages/tooling/modulekit/erc4337-validation/simulator/simulateUserOp.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "simulateUserOp"

--- a/pages/tooling/modulekit/getting-started.mdx
+++ b/pages/tooling/modulekit/getting-started.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "Getting Started"

--- a/pages/tooling/modulekit/guides/deploying/deploying-modules.mdx
+++ b/pages/tooling/modulekit/guides/deploying/deploying-modules.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "How to use ModuleKit to deploy modules"

--- a/pages/tooling/modulekit/guides/migration-guide.mdx
+++ b/pages/tooling/modulekit/guides/migration-guide.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "Migration Guide"

--- a/pages/tooling/modulekit/guides/testing/calculating-gas.mdx
+++ b/pages/tooling/modulekit/guides/testing/calculating-gas.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "How to use ModuleKit to calculate gas consumption of modules"

--- a/pages/tooling/modulekit/guides/testing/erc7579-compliance.mdx
+++ b/pages/tooling/modulekit/guides/testing/erc7579-compliance.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "How to use ModuleKit to test for ERC-7579 compliance"

--- a/pages/tooling/modulekit/guides/testing/simulating-userops.mdx
+++ b/pages/tooling/modulekit/guides/testing/simulating-userops.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "How to use ModuleKit to test ERC-4337 restrictions"

--- a/pages/tooling/modulekit/guides/testing/using-accounts.mdx
+++ b/pages/tooling/modulekit/guides/testing/using-accounts.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "How to use ModuleKit with different accounts"

--- a/pages/tooling/modulekit/index.mdx
+++ b/pages/tooling/modulekit/index.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 # ModuleKit
 

--- a/pages/tooling/modulekit/module-registry/getting-started.mdx
+++ b/pages/tooling/modulekit/module-registry/getting-started.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "Getting Started"

--- a/pages/tooling/modulekit/module-registry/glossary/types.mdx
+++ b/pages/tooling/modulekit/module-registry/glossary/types.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "Glossary"

--- a/pages/tooling/modulekit/module-registry/integrations/account.mdx
+++ b/pages/tooling/modulekit/module-registry/integrations/account.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "How to integrate the Registry into a smart account"

--- a/pages/tooling/modulekit/module-registry/integrations/wallet.mdx
+++ b/pages/tooling/modulekit/module-registry/integrations/wallet.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "How to integrate the Registry into a smart wallet"

--- a/pages/tooling/modulekit/module-registry/modules/calcModuleAddress.mdx
+++ b/pages/tooling/modulekit/module-registry/modules/calcModuleAddress.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "calcModuleAddress"

--- a/pages/tooling/modulekit/module-registry/modules/deployModule.mdx
+++ b/pages/tooling/modulekit/module-registry/modules/deployModule.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "deployModule"

--- a/pages/tooling/modulekit/module-registry/modules/deployViaFactory.mdx
+++ b/pages/tooling/modulekit/module-registry/modules/deployViaFactory.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "deployViaFactory"

--- a/pages/tooling/modulekit/module-registry/modules/findModule.mdx
+++ b/pages/tooling/modulekit/module-registry/modules/findModule.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "findModule"

--- a/pages/tooling/modulekit/module-registry/modules/registerModule.mdx
+++ b/pages/tooling/modulekit/module-registry/modules/registerModule.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "registerModule"

--- a/pages/tooling/modulekit/module-registry/overview.mdx
+++ b/pages/tooling/modulekit/module-registry/overview.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "Overview"

--- a/pages/tooling/modulekit/module-registry/querying/check.mdx
+++ b/pages/tooling/modulekit/module-registry/querying/check.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "check"

--- a/pages/tooling/modulekit/module-registry/querying/checkForAccount.mdx
+++ b/pages/tooling/modulekit/module-registry/querying/checkForAccount.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "checkForAccount"

--- a/pages/tooling/modulekit/module-registry/querying/findTrustedAttesters.mdx
+++ b/pages/tooling/modulekit/module-registry/querying/findTrustedAttesters.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "findTrustedAttesters"

--- a/pages/tooling/modulekit/module-registry/querying/trustAttesters.mdx
+++ b/pages/tooling/modulekit/module-registry/querying/trustAttesters.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "trustAttesters"

--- a/pages/tooling/modulekit/module-registry/usage/mock-attestation.mdx
+++ b/pages/tooling/modulekit/module-registry/usage/mock-attestation.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "How to make a mock attestation to use a module on testnet"

--- a/pages/tooling/modulekit/reference/building/core/isInitialized.mdx
+++ b/pages/tooling/modulekit/reference/building/core/isInitialized.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "isInitialized"

--- a/pages/tooling/modulekit/reference/building/core/isModuleType.mdx
+++ b/pages/tooling/modulekit/reference/building/core/isModuleType.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "isModuleType"

--- a/pages/tooling/modulekit/reference/building/core/name.mdx
+++ b/pages/tooling/modulekit/reference/building/core/name.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "name"

--- a/pages/tooling/modulekit/reference/building/core/onInstall.mdx
+++ b/pages/tooling/modulekit/reference/building/core/onInstall.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "onInstall"

--- a/pages/tooling/modulekit/reference/building/core/onUninstall.mdx
+++ b/pages/tooling/modulekit/reference/building/core/onUninstall.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "onUninstall"

--- a/pages/tooling/modulekit/reference/building/core/version.mdx
+++ b/pages/tooling/modulekit/reference/building/core/version.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "version"

--- a/pages/tooling/modulekit/reference/building/executors/execute.mdx
+++ b/pages/tooling/modulekit/reference/building/executors/execute.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "execute"

--- a/pages/tooling/modulekit/reference/building/executors/executeDelegateCall.mdx
+++ b/pages/tooling/modulekit/reference/building/executors/executeDelegateCall.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "_executeDelegateCall"

--- a/pages/tooling/modulekit/reference/building/fallbacks/msgSender.mdx
+++ b/pages/tooling/modulekit/reference/building/fallbacks/msgSender.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "_msgSender"

--- a/pages/tooling/modulekit/reference/building/hooks/onExecute.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/onExecute.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "onExecute"

--- a/pages/tooling/modulekit/reference/building/hooks/onExecuteBatch.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/onExecuteBatch.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "onExecuteBatch"

--- a/pages/tooling/modulekit/reference/building/hooks/onExecuteBatchFromExecutor.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/onExecuteBatchFromExecutor.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "onExecuteBatchFromExecutor"

--- a/pages/tooling/modulekit/reference/building/hooks/onExecuteFromExecutor.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/onExecuteFromExecutor.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "onExecuteFromExecutor"

--- a/pages/tooling/modulekit/reference/building/hooks/onInstallModule.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/onInstallModule.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "onInstallModule"

--- a/pages/tooling/modulekit/reference/building/hooks/onPostCheck.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/onPostCheck.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "onPostCheck"

--- a/pages/tooling/modulekit/reference/building/hooks/onUninstallModule.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/onUninstallModule.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "onUninstallModule"

--- a/pages/tooling/modulekit/reference/building/hooks/onUnknownFunction.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/onUnknownFunction.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "onUnknownFunction"

--- a/pages/tooling/modulekit/reference/building/hooks/postCheck.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/postCheck.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "_postCheck"

--- a/pages/tooling/modulekit/reference/building/hooks/preCheck.mdx
+++ b/pages/tooling/modulekit/reference/building/hooks/preCheck.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "_preCheck"

--- a/pages/tooling/modulekit/reference/building/registry-adapter/registry.mdx
+++ b/pages/tooling/modulekit/reference/building/registry-adapter/registry.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "REGISTRY"

--- a/pages/tooling/modulekit/reference/building/scheduling-module/executeOrder.mdx
+++ b/pages/tooling/modulekit/reference/building/scheduling-module/executeOrder.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "executeOrder"

--- a/pages/tooling/modulekit/reference/building/smart-sessions/check1271SignedAction.mdx
+++ b/pages/tooling/modulekit/reference/building/smart-sessions/check1271SignedAction.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "check1271SignedAction"

--- a/pages/tooling/modulekit/reference/building/smart-sessions/checkAction.mdx
+++ b/pages/tooling/modulekit/reference/building/smart-sessions/checkAction.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "checkAction"

--- a/pages/tooling/modulekit/reference/building/smart-sessions/checkUserOp.mdx
+++ b/pages/tooling/modulekit/reference/building/smart-sessions/checkUserOp.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "checkUserOp"

--- a/pages/tooling/modulekit/reference/building/smart-sessions/initializeWithMultiplexer.mdx
+++ b/pages/tooling/modulekit/reference/building/smart-sessions/initializeWithMultiplexer.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "initializeWithMultiplexer"

--- a/pages/tooling/modulekit/reference/building/trusted-forwarder/getAccount.mdx
+++ b/pages/tooling/modulekit/reference/building/trusted-forwarder/getAccount.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "_getAccount"

--- a/pages/tooling/modulekit/reference/building/validators/isValidSignatureWithSender.mdx
+++ b/pages/tooling/modulekit/reference/building/validators/isValidSignatureWithSender.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "isValidSignatureWithSender"

--- a/pages/tooling/modulekit/reference/building/validators/packValidationData.mdx
+++ b/pages/tooling/modulekit/reference/building/validators/packValidationData.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "_packValidationData"

--- a/pages/tooling/modulekit/reference/building/validators/unpackValidationData.mdx
+++ b/pages/tooling/modulekit/reference/building/validators/unpackValidationData.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "_unpackValidationData"

--- a/pages/tooling/modulekit/reference/building/validators/validateUserOp.mdx
+++ b/pages/tooling/modulekit/reference/building/validators/validateUserOp.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "validateUserOp"

--- a/pages/tooling/modulekit/reference/checknsignatures/checknsignaturesfoundryhelper/sign.mdx
+++ b/pages/tooling/modulekit/reference/checknsignatures/checknsignaturesfoundryhelper/sign.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "sign"

--- a/pages/tooling/modulekit/reference/checknsignatures/checksignatures/recoverNSignatures.mdx
+++ b/pages/tooling/modulekit/reference/checknsignatures/checksignatures/recoverNSignatures.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "recoverNSignatures"

--- a/pages/tooling/modulekit/reference/deploying/attestations/isModuleAttestedMock.mdx
+++ b/pages/tooling/modulekit/reference/deploying/attestations/isModuleAttestedMock.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "isModuleAttestedMock"

--- a/pages/tooling/modulekit/reference/deploying/attestations/mockAttestToModule.mdx
+++ b/pages/tooling/modulekit/reference/deploying/attestations/mockAttestToModule.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "mockAttestToModule"

--- a/pages/tooling/modulekit/reference/deploying/core/deployModule.mdx
+++ b/pages/tooling/modulekit/reference/deploying/core/deployModule.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "deployModule"

--- a/pages/tooling/modulekit/reference/deploying/core/deployModuleViaFactory.mdx
+++ b/pages/tooling/modulekit/reference/deploying/core/deployModuleViaFactory.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "deployModuleViaFactory"

--- a/pages/tooling/modulekit/reference/deploying/core/predictModuleAddress.mdx
+++ b/pages/tooling/modulekit/reference/deploying/core/predictModuleAddress.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "predictModuleAddress"

--- a/pages/tooling/modulekit/reference/deploying/core/registerModule.mdx
+++ b/pages/tooling/modulekit/reference/deploying/core/registerModule.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "registerModule"

--- a/pages/tooling/modulekit/reference/deploying/registry/findModule.mdx
+++ b/pages/tooling/modulekit/reference/deploying/registry/findModule.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "findModule"

--- a/pages/tooling/modulekit/reference/deploying/registry/findResolver.mdx
+++ b/pages/tooling/modulekit/reference/deploying/registry/findResolver.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "findResolver"

--- a/pages/tooling/modulekit/reference/deploying/registry/findSchema.mdx
+++ b/pages/tooling/modulekit/reference/deploying/registry/findSchema.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "findSchema"

--- a/pages/tooling/modulekit/reference/deploying/registry/registerResolver.mdx
+++ b/pages/tooling/modulekit/reference/deploying/registry/registerResolver.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "registerResolver"

--- a/pages/tooling/modulekit/reference/deploying/registry/registerSchema.mdx
+++ b/pages/tooling/modulekit/reference/deploying/registry/registerSchema.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "registerSchema"

--- a/pages/tooling/modulekit/reference/deploying/registry/setRegistry.mdx
+++ b/pages/tooling/modulekit/reference/deploying/registry/setRegistry.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "setRegistry"

--- a/pages/tooling/modulekit/reference/deploying/registry/setResolverUID.mdx
+++ b/pages/tooling/modulekit/reference/deploying/registry/setResolverUID.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "setResolverUID"

--- a/pages/tooling/modulekit/reference/deploying/registry/setSchemaUID.mdx
+++ b/pages/tooling/modulekit/reference/deploying/registry/setSchemaUID.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "setSchemaUID"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/flatbytes/flatbyteslib/clear.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/flatbytes/flatbyteslib/clear.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "clear"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/flatbytes/flatbyteslib/load.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/flatbytes/flatbyteslib/load.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "load"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/flatbytes/flatbyteslib/store.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/flatbytes/flatbyteslib/store.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "store"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/alreadyInitialized.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/alreadyInitialized.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "alreadyInitialized"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/contains.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/contains.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "contains"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/getEntriesPaginated.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/getEntriesPaginated.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "getEntriesPaginated"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/getNext.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/getNext.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "getNext"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/init.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/init.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "init"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/pop.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/pop.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "pop"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/popAll.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/popAll.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "popAll"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/push.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/push.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "push"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/safePush.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/linkedbytes32lib/safePush.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "safePush"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/alreadyInitialized.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/alreadyInitialized.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "alreadyInitialized"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/contains.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/contains.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "contains"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/getEntriesPaginated.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/getEntriesPaginated.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "getEntriesPaginated"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/getNext.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/getNext.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "getNext"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/init.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/init.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "init"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/pop.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/pop.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "pop"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/popAll.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/popAll.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "popAll"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/push.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/push.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "push"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/safePush.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellist4337lib/safePush.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "safePush"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellisthelper/findPrevious.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellisthelper/findPrevious.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "findPrevious"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/alreadyInitialized.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/alreadyInitialized.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "alreadyInitialized"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/contains.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/contains.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "contains"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/getEntriesPaginated.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/getEntriesPaginated.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "getEntriesPaginated"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/getNext.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/getNext.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "getNext"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/init.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/init.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "init"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/pop.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/pop.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "pop"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/popAll.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/popAll.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "popAll"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/push.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/push.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "push"

--- a/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/safePush.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-data-libs/sentinellist/sentinellistlib/safePush.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "safePush"

--- a/pages/tooling/modulekit/reference/erc4337-validation/simulator/simulateUserOp.mdx
+++ b/pages/tooling/modulekit/reference/erc4337-validation/simulator/simulateUserOp.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "simulateUserOp"

--- a/pages/tooling/modulekit/reference/glossary/types.mdx
+++ b/pages/tooling/modulekit/reference/glossary/types.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "Types in ModuleKit"

--- a/pages/tooling/modulekit/reference/testing/core/exec.mdx
+++ b/pages/tooling/modulekit/reference/testing/core/exec.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "exec"

--- a/pages/tooling/modulekit/reference/testing/core/execUserOps.mdx
+++ b/pages/tooling/modulekit/reference/testing/core/execUserOps.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "execUserOps"

--- a/pages/tooling/modulekit/reference/testing/core/getExecOps.mdx
+++ b/pages/tooling/modulekit/reference/testing/core/getExecOps.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "getExecOps"

--- a/pages/tooling/modulekit/reference/testing/core/makeAccountInstance.mdx
+++ b/pages/tooling/modulekit/reference/testing/core/makeAccountInstance.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "makeAccountInstance"

--- a/pages/tooling/modulekit/reference/testing/modules/getInstalledModules.mdx
+++ b/pages/tooling/modulekit/reference/testing/modules/getInstalledModules.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "getInstalledModules"

--- a/pages/tooling/modulekit/reference/testing/modules/installModule.mdx
+++ b/pages/tooling/modulekit/reference/testing/modules/installModule.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "installModule"

--- a/pages/tooling/modulekit/reference/testing/modules/isModuleInstalled.mdx
+++ b/pages/tooling/modulekit/reference/testing/modules/isModuleInstalled.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "isModuleInstalled"

--- a/pages/tooling/modulekit/reference/testing/modules/uninstallModule.mdx
+++ b/pages/tooling/modulekit/reference/testing/modules/uninstallModule.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "uninstallModule"

--- a/pages/tooling/modulekit/reference/testing/signature-validation/formatERC1271Hash.mdx
+++ b/pages/tooling/modulekit/reference/testing/signature-validation/formatERC1271Hash.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "formatERC1271Hash"

--- a/pages/tooling/modulekit/reference/testing/signature-validation/formatERC1271Signature.mdx
+++ b/pages/tooling/modulekit/reference/testing/signature-validation/formatERC1271Signature.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "formatERC1271Signature"

--- a/pages/tooling/modulekit/reference/testing/signature-validation/isValidSignature.mdx
+++ b/pages/tooling/modulekit/reference/testing/signature-validation/isValidSignature.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "isValidSignature"

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/addSession.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/addSession.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "addSession"

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/encodeSignature.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/encodeSignature.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "encodeSignature"

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/getPermissionId.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/getPermissionId.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "getPermissionId"

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/getSessionDigest.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/getSessionDigest.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "getSessionDigest"

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/getSessionNonce.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/getSessionNonce.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "getSessionNonce"

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/isPermissionEnabled.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/isPermissionEnabled.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "isPermissionEnabled"

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/isSessionEnabled.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/isSessionEnabled.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "isSessionEnabled"

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/makeMultiChainEnableData.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/makeMultiChainEnableData.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "makeMultiChainEnableData"

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/removeSession.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/removeSession.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "removeSession"

--- a/pages/tooling/modulekit/reference/testing/smart-sessions/useSession.mdx
+++ b/pages/tooling/modulekit/reference/testing/smart-sessions/useSession.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "useSession"

--- a/pages/tooling/modulekit/reference/testing/utilities/deployAccount.mdx
+++ b/pages/tooling/modulekit/reference/testing/utilities/deployAccount.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "deployAccount"

--- a/pages/tooling/modulekit/reference/testing/utilities/expect4337Revert.mdx
+++ b/pages/tooling/modulekit/reference/testing/utilities/expect4337Revert.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "expect4337Revert"

--- a/pages/tooling/modulekit/reference/testing/utilities/log4337Gas.mdx
+++ b/pages/tooling/modulekit/reference/testing/utilities/log4337Gas.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "log4337Gas"

--- a/pages/tooling/modulekit/reference/testing/utilities/setAccountEnv.mdx
+++ b/pages/tooling/modulekit/reference/testing/utilities/setAccountEnv.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "setAccountEnv"

--- a/pages/tooling/modulekit/reference/testing/utilities/simulateUserOp.mdx
+++ b/pages/tooling/modulekit/reference/testing/utilities/simulateUserOp.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "simulateUserOp"

--- a/pages/tooling/modulekit/reference/testing/utilities/withModuleStorageClearValidation.mdx
+++ b/pages/tooling/modulekit/reference/testing/utilities/withModuleStorageClearValidation.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "withModuleStorageClearValidation"

--- a/pages/tooling/modulekit/tutorials/auto-swap-executor.mdx
+++ b/pages/tooling/modulekit/tutorials/auto-swap-executor.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "Tutorial 2: Building an Auto-swap Executor"

--- a/pages/tooling/modulekit/tutorials/multi-owner-validator.mdx
+++ b/pages/tooling/modulekit/tutorials/multi-owner-validator.mdx
@@ -1,9 +1,6 @@
 > ⚠️ **Deprecation Notice**
 >
-> ModuleKit was developed by Rhinestone and is no longer actively supported. 
-> For new projects, we recommend using the **Rhinestone SDK** instead.
->
-> **→ [Rhinestone SDK Documentation](https://docs.rhinestone.dev)**
+> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev
 
 ---
 title: "Tutorial 1: Building a Muti-Owner Validator"


### PR DESCRIPTION
## Summary

- Updated ModuleKit deprecation disclaimer across all 134 pages
- Removed link to Rhinestone SDK documentation
- Added contact email (gm@rhinestone.dev) for module builders needing assistance

## New Disclaimer Text

> ⚠️ **Deprecation Notice**
>
> ModuleKit was developed by Rhinestone and is no longer actively supported. If you're building modules and need assistance, reach out to Rhinestone at gm@rhinestone.dev

## Test plan

- [ ] Verify updated disclaimers render correctly on ModuleKit pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)